### PR TITLE
Rename AutoClosedAttribute to UnionAttribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 *.DotSettings.user
+*.received.txt

--- a/src/Kehlet.Functional.Generators.UnionGenerator.Sample/TokenKind.cs
+++ b/src/Kehlet.Functional.Generators.UnionGenerator.Sample/TokenKind.cs
@@ -1,6 +1,6 @@
 ﻿namespace Kehlet.Functional.Generators.UnionGenerator.Sample;
 
-[AutoClosed(true)]
+[Union(true)]
 public partial record TokenKind
 {
     partial record Name(string Value);

--- a/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.RunResult.verified.txt
+++ b/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.RunResult.verified.txt
@@ -3,9 +3,9 @@
   GeneratedSources: [
     {
       SyntaxTree: {
-        FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.AutoClosedAttribute.g.cs,
+        FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.UnionAttribute.g.cs,
         Encoding: utf-8,
-        Length: 219,
+        Length: 214,
         HasCompilationUnitRoot: true,
         Options: {
           LanguageVersion: CSharp12,
@@ -22,12 +22,12 @@ using System;
 namespace Kehlet.Functional;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class AutoClosedAttribute(bool serializable = false) : Attribute
+public class UnionAttribute(bool serializable = false) : Attribute
 {
     public bool IsSerializable => serializable;
 }
 ,
-        Length: 219,
+        Length: 214,
         ChecksumAlgorithm: Sha1,
         CanBeEmbedded: true,
         Container: {},
@@ -99,74 +99,74 @@ public class AutoClosedAttribute(bool serializable = false) : Attribute
           {
             LineNumber: 5,
             Start: 91,
-            End: 162,
-            EndIncludingLineBreak: 164,
+            End: 157,
+            EndIncludingLineBreak: 159,
             Span: {
               Start: 91,
-              Length: 71
+              Length: 66
             },
             SpanIncludingLineBreak: {
               Start: 91,
-              Length: 73
+              Length: 68
             }
           },
           {
             LineNumber: 6,
-            Start: 164,
-            End: 165,
-            EndIncludingLineBreak: 167,
+            Start: 159,
+            End: 160,
+            EndIncludingLineBreak: 162,
             Span: {
-              Start: 164,
+              Start: 159,
               Length: 1
             },
             SpanIncludingLineBreak: {
-              Start: 164,
+              Start: 159,
               Length: 3
             }
           },
           {
             LineNumber: 7,
-            Start: 167,
-            End: 214,
-            EndIncludingLineBreak: 216,
+            Start: 162,
+            End: 209,
+            EndIncludingLineBreak: 211,
             Span: {
-              Start: 167,
+              Start: 162,
               Length: 47
             },
             SpanIncludingLineBreak: {
-              Start: 167,
+              Start: 162,
               Length: 49
             }
           },
           {
             LineNumber: 8,
-            Start: 216,
-            End: 217,
-            EndIncludingLineBreak: 219,
+            Start: 211,
+            End: 212,
+            EndIncludingLineBreak: 214,
             Span: {
-              Start: 216,
+              Start: 211,
               Length: 1
             },
             SpanIncludingLineBreak: {
-              Start: 216,
+              Start: 211,
               Length: 3
             }
           },
           {
             LineNumber: 9,
-            Start: 219,
-            End: 219,
-            EndIncludingLineBreak: 219,
+            Start: 214,
+            End: 214,
+            EndIncludingLineBreak: 214,
             Span: {
-              Start: 219
+              Start: 214
             },
             SpanIncludingLineBreak: {
-              Start: 219
+              Start: 214
             }
           }
         ]
       },
-      HintName: Kehlet.Functional.AutoClosedAttribute.g.cs
+      HintName: Kehlet.Functional.UnionAttribute.g.cs
     },
     {
       SyntaxTree: {

--- a/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.RunResults.verified.txt
+++ b/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.RunResults.verified.txt
@@ -5,9 +5,9 @@
       GeneratedSources: [
         {
           SyntaxTree: {
-            FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.AutoClosedAttribute.g.cs,
+            FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.UnionAttribute.g.cs,
             Encoding: utf-8,
-            Length: 219,
+            Length: 214,
             HasCompilationUnitRoot: true,
             Options: {
               LanguageVersion: CSharp12,
@@ -24,12 +24,12 @@ using System;
 namespace Kehlet.Functional;
 
 [AttributeUsage(AttributeTargets.Class)]
-public class AutoClosedAttribute(bool serializable = false) : Attribute
+public class UnionAttribute(bool serializable = false) : Attribute
 {
     public bool IsSerializable => serializable;
 }
 ,
-            Length: 219,
+            Length: 214,
             ChecksumAlgorithm: Sha1,
             CanBeEmbedded: true,
             Container: {},
@@ -101,74 +101,74 @@ public class AutoClosedAttribute(bool serializable = false) : Attribute
               {
                 LineNumber: 5,
                 Start: 91,
-                End: 162,
-                EndIncludingLineBreak: 164,
+                End: 157,
+                EndIncludingLineBreak: 159,
                 Span: {
                   Start: 91,
-                  Length: 71
+                  Length: 66
                 },
                 SpanIncludingLineBreak: {
                   Start: 91,
-                  Length: 73
+                  Length: 68
                 }
               },
               {
                 LineNumber: 6,
-                Start: 164,
-                End: 165,
-                EndIncludingLineBreak: 167,
+                Start: 159,
+                End: 160,
+                EndIncludingLineBreak: 162,
                 Span: {
-                  Start: 164,
+                  Start: 159,
                   Length: 1
                 },
                 SpanIncludingLineBreak: {
-                  Start: 164,
+                  Start: 159,
                   Length: 3
                 }
               },
               {
                 LineNumber: 7,
-                Start: 167,
-                End: 214,
-                EndIncludingLineBreak: 216,
+                Start: 162,
+                End: 209,
+                EndIncludingLineBreak: 211,
                 Span: {
-                  Start: 167,
+                  Start: 162,
                   Length: 47
                 },
                 SpanIncludingLineBreak: {
-                  Start: 167,
+                  Start: 162,
                   Length: 49
                 }
               },
               {
                 LineNumber: 8,
-                Start: 216,
-                End: 217,
-                EndIncludingLineBreak: 219,
+                Start: 211,
+                End: 212,
+                EndIncludingLineBreak: 214,
                 Span: {
-                  Start: 216,
+                  Start: 211,
                   Length: 1
                 },
                 SpanIncludingLineBreak: {
-                  Start: 216,
+                  Start: 211,
                   Length: 3
                 }
               },
               {
                 LineNumber: 9,
-                Start: 219,
-                End: 219,
-                EndIncludingLineBreak: 219,
+                Start: 214,
+                End: 214,
+                EndIncludingLineBreak: 214,
                 Span: {
-                  Start: 219
+                  Start: 214
                 },
                 SpanIncludingLineBreak: {
-                  Start: 219
+                  Start: 214
                 }
               }
             ]
           },
-          HintName: Kehlet.Functional.AutoClosedAttribute.g.cs
+          HintName: Kehlet.Functional.UnionAttribute.g.cs
         },
         {
           SyntaxTree: {
@@ -1754,9 +1754,9 @@ abstract public partial class Option<TValue>
   Diagnostics: null,
   GeneratedTrees: [
     {
-      FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.AutoClosedAttribute.g.cs,
+      FilePath: Kehlet.Functional.Generators.UnionGenerator\Kehlet.Functional.Generators.UnionGenerator.UnionGenerator\Kehlet.Functional.UnionAttribute.g.cs,
       Encoding: utf-8,
-      Length: 219,
+      Length: 214,
       HasCompilationUnitRoot: true,
       Options: {
         LanguageVersion: CSharp12,

--- a/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.cs
+++ b/src/Kehlet.Functional.Generators.UnionGenerator.Tests/UnionGeneratorTests.cs
@@ -14,7 +14,7 @@ public class UnionGeneratorTests
     private const string UnionClassText = """
         namespace TestNamespace;
         
-        [Kehlet.Functional.AutoClosed(true)]
+        [Kehlet.Functional.Union(true)]
         public partial record TokenKind
         {
             partial record Number(string Value);
@@ -22,7 +22,7 @@ public class UnionGeneratorTests
             partial record Minus;
         }
         
-        [Kehlet.Functional.AutoClosed]
+        [Kehlet.Functional.Union]
         public partial class Option<TValue>
         {
             partial class Some(TValue Value);

--- a/src/Kehlet.Functional.Generators.UnionGenerator/UnionGenerator.cs
+++ b/src/Kehlet.Functional.Generators.UnionGenerator/UnionGenerator.cs
@@ -13,7 +13,7 @@ namespace Kehlet.Functional.Generators.UnionGenerator;
 public class UnionGenerator : IIncrementalGenerator
 {
     private const string AttributeNamespace = "Kehlet.Functional";
-    private const string AttributeName = "AutoClosedAttribute";
+    private const string AttributeName = "UnionAttribute";
     private const string AttributeFullName = $"{AttributeNamespace}.{AttributeName}";
     
     public void Initialize(IncrementalGeneratorInitializationContext context)


### PR DESCRIPTION
In this commit, the `AutoClosedAttribute` class has been renamed to `UnionAttribute` across all files. This change improves semantic clarity as it more accurately describes the function of the attribute. All relevant tests and file paths have also been adjusted to reflect this rename.