### PR TITLE
Update README.md for UnionGenerator

### DIFF
--- a/src/Kehlet.Functional.Generators.UnionGenerator/README.md
+++ b/src/Kehlet.Functional.Generators.UnionGenerator/README.md
@@ -1,3 +1,6 @@
-﻿Companion source generator to ExhaustiveMatching.Analyzer  
-Use AutoClosedAttribute on the enclosing type to automatically generate the Closed attribute.  
-Partial case types will automatically inherit from the enclosing type.
+﻿Companion source generator to `ExhaustiveMatching.Analyzer`  
+Use `Kehlet.Functional.UnionAttribute` on the enclosing type to close the union and apply `ExhaustiveMatching.ClosedAttribute` for the analyzer.  
+- Containing type will be marked abstract and get a private constructor.
+- Contained types will be marked public and sealed.
+- Contained types will inherit from the containing type.
+- Containing type will have ClosedAttribute applied for all contained types.


### PR DESCRIPTION
The README file for the UnionGenerator has been updated with details on how to use the `Kehlet.Functional.UnionAttribute` for enclosing types and the impact on containing and contained types. This revision provides clearer instructions on how and where to apply attributes for exhaustive matching.